### PR TITLE
Realloc

### DIFF
--- a/homeTask1/bn.c
+++ b/homeTask1/bn.c
@@ -1,11 +1,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-//#include "bn.h"
+#include "bn.h"
 
 //#define MOD 4294967296 // 2^32
-//const long long MOD = 4294967296;
-const long long MOD = 1000000000;
+const long long MOD = 4294967296;
 
 struct bn_s{
     // array of digits in base 2^32


### PR DESCRIPTION
Implemented a new way to manage digits
Closes #3 
there is a new property in the `struct bn` 
```c
    int allocd;
```
`allocd` represents the number of allocated integers in the `bn::digit` array

and there is a new function 

```c
int bn_resize(bn* t, int new_size){
    t->size = new_size;

    if(new_size > t->allocd){
        t->digit = (unsigned int*)realloc(t->digit, 2 * t->allocd * sizeof(unsigned int));
        t->allocd *= 2;
    }
    return 0;
}
```
It changes the `bn::size` property and reallocates memory if needed